### PR TITLE
Make sure primary landing page fits, even on iPhone Mini

### DIFF
--- a/server/vb/templates/components/countdown.dhtml
+++ b/server/vb/templates/components/countdown.dhtml
@@ -5,8 +5,7 @@
       flex-direction: column;
       align-items: center;
       justify-content: center;
-      padding-bottom: 1em;
-      padding-top: 1em;
+      padding-bottom: 0.5rem;
     }
 
     me p {

--- a/server/vb/templates/school.dhtml
+++ b/server/vb/templates/school.dhtml
@@ -17,7 +17,13 @@
       me main {
         width: 100%;
         text-align: center;
-        padding: 2rem 0;
+        padding-bottom: 2rem;
+      }
+
+      @media screen and (min-width: 768px) {
+        me main {
+          padding: 2rem 0;
+        }
       }
 
       me main img {


### PR DESCRIPTION
Removes some vertical spacing to make things fit better; the primary action button should always be "above the fold" now.

<img width="534" alt="Screenshot 2024-04-30 at 9 59 29 AM" src="https://github.com/front-seat/voterbowl/assets/53165/5280fcb9-25ba-4ee4-a2e0-05c7bcb22938">
